### PR TITLE
Introduce optional parse options

### DIFF
--- a/convenience.go
+++ b/convenience.go
@@ -95,6 +95,13 @@ func Foreground(color colorful.Color) StyleOption {
 	}
 }
 
+// EnableTextAnnotations enables post-processing to evaluate text annotations
+func EnableTextAnnotations() StyleOption {
+	return func(s *String) {
+		processTextAnnotations(s)
+	}
+}
+
 // Style is a multi-purpose function to programmatically apply styles and other
 // changes to an input text. The function will panic in the unlikely case of a
 // parse issue.

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -80,5 +80,15 @@ var _ = Describe("convenience functions", func() {
 			Expect(Style("text", Bold(), Foreground(CornflowerBlue))).To(
 				BeEquivalentTo("\x1b[1;38;2;100;149;237mtext\x1b[0m"))
 		})
+
+		It("should not evaluate special text annotations by default", func() {
+			Expect(Style("_text_", Foreground(YellowGreen))).To(
+				BeEquivalentTo("\x1b[38;2;154;205;50m_text_\x1b[0m"))
+		})
+
+		It("should evaluate special text annotations if enabled", func() {
+			Expect(Style("_text_", Foreground(YellowGreen), EnableTextAnnotations())).To(
+				BeEquivalentTo("\x1b[3;38;2;154;205;50mtext\x1b[0m"))
+		})
 	})
 })

--- a/parse_test.go
+++ b/parse_test.go
@@ -127,7 +127,7 @@ var _ = Describe("parse input string", func() {
 	Context("parse markdown style text annotations", func() {
 		It("should parse an input string with markdown style text annotations", func() {
 			input := "Example: *bold*, _italic_, ~underline~, and CornflowerBlue{foreground}."
-			result, err := ParseString(input)
+			result, err := ParseString(input, ProcessTextAnnotations())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*result).To(
 				BeEquivalentTo(String([]ColoredRune{
@@ -185,7 +185,7 @@ var _ = Describe("parse input string", func() {
 
 		It("should bail out nicely in case of invalid color name", func() {
 			input := "Invalid: InvalidColor{foobar}."
-			result, err := ParseString(input)
+			result, err := ParseString(input, ProcessTextAnnotations())
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -193,7 +193,8 @@ var _ = Describe("parse input string", func() {
 
 	Context("parse input string with multi-byte characters", func() {
 		It("should correctly parse multi-byte character strings", func() {
-			result, err := ParseString("Gray{Debug➤ Found asset file} White{X} with permission White{Y}")
+			input := "Gray{Debug➤ Found asset file} White{X} with permission White{Y}"
+			result, err := ParseString(input, ProcessTextAnnotations())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).ToNot(BeNil())
 			Expect(result.String()).To(

--- a/print.go
+++ b/print.go
@@ -37,12 +37,12 @@ func evaluateInputs(in ...interface{}) []interface{} {
 	return result
 }
 
-func evaluateString(in string) string {
-	if result, err := ParseString(in); err == nil {
+func evaluateString(input string) string {
+	if result, err := ParseString(input, ProcessTextAnnotations()); err == nil {
 		return result.String()
 	}
 
-	return in
+	return input
 }
 
 // Print wraps fmt.Print(a ...interface{}) and evaluates any text markers into its respective format

--- a/render_test.go
+++ b/render_test.go
@@ -75,7 +75,8 @@ var _ = Describe("render colored strings", func() {
 
 		var (
 			f1 = func(color string) string {
-				result, err := ParseString(fmt.Sprintf("%s{%s}", color, "text"))
+				input := fmt.Sprintf("%s{%s}", color, "text")
+				result, err := ParseString(input, ProcessTextAnnotations())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).ToNot(BeNil())
 				return result.String()


### PR DESCRIPTION
Add parse option to enable or disable special text annotation processing.

Add style option in `Style` function to enable or disable special text
annotation processing.