### PR TITLE
Add underline style and line mode for emphasis

### DIFF
--- a/convenience.go
+++ b/convenience.go
@@ -71,7 +71,12 @@ func Substring(text string, start int, end int) string {
 func Bold() StyleOption {
 	return StyleOption{
 		postProcess: func(s *String, flags map[string]struct{}) {
+			_, skipNewLine := flags["skipNewLine"]
 			for i := range *s {
+				if skipNewLine && (*s)[i].Symbol == '\n' {
+					continue
+				}
+
 				(*s)[i].Settings |= 1 << 2
 			}
 		},
@@ -82,8 +87,29 @@ func Bold() StyleOption {
 func Italic() StyleOption {
 	return StyleOption{
 		postProcess: func(s *String, flags map[string]struct{}) {
+			_, skipNewLine := flags["skipNewLine"]
 			for i := range *s {
+				if skipNewLine && (*s)[i].Symbol == '\n' {
+					continue
+				}
+
 				(*s)[i].Settings |= 1 << 3
+			}
+		},
+	}
+}
+
+// Underline applies the underline text parameter
+func Underline() StyleOption {
+	return StyleOption{
+		postProcess: func(s *String, flags map[string]struct{}) {
+			_, skipNewLine := flags["skipNewLine"]
+			for i := range *s {
+				if skipNewLine && (*s)[i].Symbol == '\n' {
+					continue
+				}
+
+				(*s)[i].Settings |= 1 << 4
 			}
 		},
 	}
@@ -95,7 +121,6 @@ func Foreground(color colorful.Color) StyleOption {
 		postProcess: func(s *String, flags map[string]struct{}) {
 			r, g, b := color.RGB255()
 			_, skipNewLine := flags["skipNewLine"]
-
 			for i := range *s {
 				if skipNewLine && (*s)[i].Symbol == '\n' {
 					continue

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -104,5 +104,25 @@ var _ = Describe("convenience functions", func() {
 			Expect(Style("text\ntext", Foreground(Yellow), EachLine())).To(
 				BeEquivalentTo("\x1b[38;2;255;255;0mtext\ntext\x1b[0m"))
 		})
+
+		It("should support text emphasis both line by line as well as full block mode", func() {
+			Expect(Style("text\ntext", Bold())).To(
+				BeEquivalentTo("\x1b[1mtext\ntext\x1b[0m"))
+
+			Expect(Style("text\ntext", Italic())).To(
+				BeEquivalentTo("\x1b[3mtext\ntext\x1b[0m"))
+
+			Expect(Style("text\ntext", Underline())).To(
+				BeEquivalentTo("\x1b[4mtext\ntext\x1b[0m"))
+
+			Expect(Style("text\ntext", EachLine(), Bold())).To(
+				BeEquivalentTo("\x1b[1mtext\x1b[0m\n\x1b[1mtext\x1b[0m"))
+
+			Expect(Style("text\ntext", EachLine(), Italic())).To(
+				BeEquivalentTo("\x1b[3mtext\x1b[0m\n\x1b[3mtext\x1b[0m"))
+
+			Expect(Style("text\ntext", EachLine(), Underline())).To(
+				BeEquivalentTo("\x1b[4mtext\x1b[0m\n\x1b[4mtext\x1b[0m"))
+		})
 	})
 })


### PR DESCRIPTION
Add `Underline` style option.

Fix missing line mode for all text emphasis styles, like bold or italic.