### PR TITLE
Add hexcolor support

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -21,6 +21,8 @@
 package bunt
 
 import (
+	"strings"
+
 	colorful "github.com/lucasb-eyer/go-colorful"
 )
 
@@ -327,9 +329,18 @@ func hexColor(scol string) colorful.Color {
 }
 
 func lookupColorByName(colorName string) *colorful.Color {
+	// Try to lookup a color by a supplied hexcode
+	if strings.HasPrefix(colorName, "#") && len(colorName) == 7 {
+		if color, err := colorful.Hex(colorName); err == nil {
+			return &color
+		}
+	}
+
+	// Try to lookup color by searching in the known colors table
 	if color, ok := colorByNameMap[colorName]; ok {
 		return &color
 	}
 
+	// Give up
 	return nil
 }

--- a/colors_test.go
+++ b/colors_test.go
@@ -206,4 +206,21 @@ var _ = Describe("color specific tests", func() {
 			Expect(f1("WhiteSmoke")).To(BeEquivalentTo(f2(97)))           // WhiteSmoke matches BrightWhite (#97)
 		})
 	})
+
+	Context("custom colors in text annotation", func() {
+		BeforeEach(func() {
+			ColorSetting = ON
+			TrueColorSetting = ON
+		})
+
+		AfterEach(func() {
+			ColorSetting = AUTO
+			TrueColorSetting = AUTO
+		})
+
+		It("should parse hexcolors in text annotations", func() {
+			Expect(Sprint("#6495ED{CornflowerBlue}")).To(
+				BeEquivalentTo(Sprint("CornflowerBlue{CornflowerBlue}")))
+		})
+	})
 })

--- a/parse.go
+++ b/parse.go
@@ -34,7 +34,7 @@ var (
 	boldMarker      = regexp.MustCompile(`\*([^*]+?)\*`)
 	italicMarker    = regexp.MustCompile(`_([^_]+?)_`)
 	underlineMarker = regexp.MustCompile(`~([^~]+?)~`)
-	colorMarker     = regexp.MustCompile(`(\w+)\{([^}]+?)\}`)
+	colorMarker     = regexp.MustCompile(`(#?\w+)\{([^}]+?)\}`)
 )
 
 // ParseOption defines parser options


### PR DESCRIPTION
Add another check to the color lookup function to parse hexcode colors
into the respective color. This enables the text annotation style to
use custom colors easily: `Sprint("#6495ED{CornflowerBlue}")`.

@m-lukas FYI