### PR TITLE
Fix print-issue for non-strings

### DIFF
--- a/print.go
+++ b/print.go
@@ -28,9 +28,11 @@ import (
 func evaluateInputs(in ...interface{}) []interface{} {
 	result := make([]interface{}, len(in))
 	for i, x := range in {
-		switch str := x.(type) {
+		switch obj := x.(type) {
 		case string:
-			result[i] = evaluateString(str)
+			result[i] = evaluateString(obj)
+		default:
+			result[i] = obj
 		}
 	}
 

--- a/print_test.go
+++ b/print_test.go
@@ -137,7 +137,7 @@ var _ = Describe("print functions", func() {
 		})
 	})
 
-	Context("weird use cases", func() {
+	Context("weird use cases and issues", func() {
 		BeforeEach(func() {
 			ColorSetting = ON
 		})
@@ -149,6 +149,12 @@ var _ = Describe("print functions", func() {
 		It("should ignore escape sequences that cannot be processed", func() {
 			Expect(Sprint("ok", "\x1b[38;2;1;2mnot ok\x1b[0m")).To(
 				BeEquivalentTo("ok\x1b[38;2;1;2mnot ok\x1b[0m"))
+		})
+		It("should not fail writing simple types", func() {
+			Expect(Sprint(42)).To(Equal("42"))
+		})
+		It("should not fail writing slices", func() {
+			Expect(Sprint([]int{42, 1})).To(Equal("[42 1]"))
 		})
 	})
 })


### PR DESCRIPTION
Fixes #37

Whenever a non string was used in the print functions, a `nil` was
returned rather than the actual input.

Add default switch case to pipe through all non-strings as-is.

Signed-off-by: Stephan Auf Der Landwehr <stephan.landwehr@ibm.com>