### PR TITLE
Fix settings overriding in string parsing

### DIFF
--- a/bunt.go
+++ b/bunt.go
@@ -40,6 +40,12 @@ const (
 	underlineMask = 0x10
 )
 
+// fgClearMask is used to clear foreground color settings
+var fgClearMask = ^fgRGBMask(255, 255, 255)
+
+// fgClearMask is used to clear foreground color settings
+var bgClearMask = ^bgRGBMask(255, 255, 255)
+
 // ColorSetting defines the coloring setting to be used
 var ColorSetting SwitchState = SwitchState{value: AUTO}
 

--- a/error.go
+++ b/error.go
@@ -20,7 +20,9 @@
 
 package bunt
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Errorf wraps fmt.Errorf(err error, format string, a ...interface{}) and evaluates any text markers into its respective format
 func Errorf(format string, a ...interface{}) error {

--- a/parse_test.go
+++ b/parse_test.go
@@ -66,6 +66,16 @@ var _ = Describe("parse input string", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).ToNot(BeNil())
 		})
+
+		It("should process complementing sequences without overriding a previous setting, i.e. setting fore- and background color", func() {
+			result, err := ParseStream(strings.NewReader("\x1b[46m\x1b[30mX\x1b[0m"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*result).To(Equal(String(
+				[]ColoredRune{
+					{'X', 0x00E9B52C01010103},
+				},
+			)))
+		})
 	})
 
 	Context("parse Select Graphic Rendition (SGR) based input", func() {


### PR DESCRIPTION
Ref: https://github.com/homeport/termshot/issues/323

Fix issue that each new SGR sequence overrides the current settings.

Add condition to allow to update the current settings so that complementing
sequences do not override each other, i.e. allow background and foreground
to be set one after the other.
